### PR TITLE
Yet another way to fix issue #1 (EJS, swig generators)

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,16 @@ function extractStrings(options) {
           generator;
 
       if (key !== 'javascript') {
-        generator = 'generateFrom' + key[0].toUpperCase() + key.slice(1).toLowerCase();
+        switch (key.toLowerCase()) {
+          case 'ejs':
+            generator = 'generateFromEJS';
+              break;
+          case 'swig':
+            generator = 'generateFromswig';
+              break;
+          default:
+            generator = 'generateFrom' + key[0].toUpperCase() + key.slice(1).toLowerCase();
+        };
         if (! jsxgettext[generator]) throw new Error('No such jsxgettext generator: ' + key);
 
         strings = jsxgettext.generate.apply(jsxgettext, jsxgettext[generator](sources[key], options));


### PR DESCRIPTION
`jsxgettext` variable will contain this:
{
  parse: [Function: parse],
  generate: [Function: gen],
  generateFromEJS: [Function: EJS],
  generateFromJinja: [Function: Jinja],
  generateFromHandlebars: [Function: Handlebars],
  generateFromJade: [Function: Jade],
  generateFromswig: [Function: swig]
}

As you can see the 'generateFrom' pattern is not consistent, the 'ejs' is fully upper case and 'swig' is fully lower case.
A switch-case at `generator` variable population is implemented to workaround this inconsistency.
This workaround doesn't duplicate the generator function like maxnachlinger's workaround.
This workaround also provides a case insensitive matching of parser names in `parsers` option of extract function.
