### PR TITLE
update jsxgettext, walk.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Zach Carter",
   "license": "Apache 2.0",
   "dependencies": {
-    "walk": "^2.3.1",
-    "jsxgettext": "^0.4.8"
+    "walk": "^2.3.9",
+    "jsxgettext": "^0.9.0"
   }
 }


### PR DESCRIPTION
Update jsxgettext to 0.9.0 and walk to 2.3.9. ES2015 extraction is needed!

@zaach - mind an r?