### PR TITLE
should use outputDir

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ var extract = require('jsxgettext-recursive');
 
 var walker = extract({
   'input-dir': './app/scripts',
-  'output-dir': './locales',
+  outputDir: './locales',
   output: 'client.pot',
   exclude: /dist/,
-  'join-existing': false,
+  joinExisting: false,
   keyword: 't',
   parsers: {
     '.js': 'javascript',

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ function extractStrings(options) {
       } else {
         strings = jsxgettext.generate(sources[key], options);
       }
-      fs.writeFileSync(path.resolve(options['output-dir'] || '', options.output), strings, "utf8");
+      fs.writeFileSync(path.resolve(options['outputDir'] || '', options.output), strings, "utf8");
     });
   });
 


### PR DESCRIPTION
@zaach  seems like this is the proper option now: https://github.com/zaach/jsxgettext/blob/5c3176a80eb18137af03b3431341ab52888724e3/lib/cli.js#L47